### PR TITLE
Make one unified Jenkinsfile for all projects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
           url: "https://${DOCKER_REPO}"
         ) {
           sh label: 'Build and push Docker image', script: """
-            docker build . --pull -t ${DOCKER_IMAGE_VERSION}"
+            docker build . --pull -t ${DOCKER_IMAGE_VERSION}
             docker push ${DOCKER_IMAGE_VERSION}
           """
         }
@@ -66,13 +66,11 @@ pipeline {
           """
         }
 
-        script {
-          sh label: 'Deploy to non-production', script: """
-            kubectl config use-context dev-${env.ZONE}
-            kubectl apply -n ${env.NAMESPACE} -f nais.yaml --wait
-            kubectl rollout status -w deployment/${APPLICATION_NAME}
-          """
-        }
+        sh label: 'Deploy to non-production', script: """
+          kubectl config use-context dev-${env.ZONE}
+          kubectl apply -n ${env.NAMESPACE} -f nais.yaml --wait
+          kubectl rollout status -w deployment/${APPLICATION_NAME}
+        """
       }
 
       post {

--- a/nais.yaml
+++ b/nais.yaml
@@ -3,6 +3,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: dagpenger-journalforing-gsak
+  namespace: default
   labels:
     team: teamdagpenger
 spec:

--- a/nais.yaml
+++ b/nais.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: default
   labels:
     team: teamdagpenger
+  annotations:
+    zone: fss
 spec:
   image: repo.adeo.no:5443/dagpenger-journalforing-gsak:latest
   port: 8080


### PR DESCRIPTION
Did several changes to the Jenkins pipeline so it can be reused for all projects.

It extracts the necessary information like application name and zone from the `nais.yaml` instead of duplicating it in both `nais.yaml` and `Jenkinsfile`. This allows the Jenkinsfile to be copied between projects. This only works for nais.yaml files in the `naiserator`-format.

Reduces the number of stages and rather use label per step in the deployment.